### PR TITLE
added: desktop notifications (on linux)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-check"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Ray Solomon <raybsolomon@gmail.com>"]
 license = "MIT"
 description = "wrapper around cargo rustc -- -Zno-trans"
@@ -8,3 +8,10 @@ keywords = ["subcommand", "cargo"]
 readme = "README.md"
 repository = "https://github.com/rsolomo/cargo-check"
 homepage = "https://github.com/rsolomo/cargo-check"
+
+[features]
+notifications = ["notify-rust"]
+
+[dependencies.notify-rust]
+version = "~3.0"
+optional = true

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,6 @@
+#[cfg(all(feature = "notifications", target_os="linux"))]
+extern crate notify_rust;
+
 #[cfg(not(test))]
 fn main() {
     use std::env;
@@ -10,8 +13,36 @@ fn main() {
     let exit_status = child.wait().unwrap_or_else(|e| panic!("{}", e));
 
     if let Some(code) = exit_status.code() {
+        notify(exit_status.success());
         process::exit(code);
     }
+}
+
+#[cfg(all(feature = "notifications", target_os="linux"))]
+fn notify(success:bool){
+    use notify_rust::Notification;
+
+    if success {
+        Notification::new()
+            .summary("Cargo Check Ok")
+            .body("crate would probably compile")
+            .icon("dialog-ok")
+            .show().unwrap();
+    }
+    else{
+        Notification::new()
+            .summary("Cargo Check")
+            .body("crate would not compile")
+            .icon("dialog-cancel")
+            .show().unwrap();
+    }
+
+}
+
+#[cfg(not(feature = "notifications"))]
+fn notify(_success:bool){
+    //println!("build without notifications");
+    //do nothing here
 }
 
 fn wrap_args<T, I>(it: I) -> Vec<String>


### PR DESCRIPTION
Hi there,
I'm using `cargo check` in combination with `cargo watch`. In this combination, wouldn't it be cool if the watcher in the background would notify you if your crate no longer would compile?
At least I liked that idea :smile: 
So I added a `feature` which enables desktop notifications (only on linux so far).

What do you think?