### PR TITLE
Fix multiple target checking introduced in #13.

### DIFF
--- a/tests/fixtures/multitarget/src/lib.rs
+++ b/tests/fixtures/multitarget/src/lib.rs
@@ -1,3 +1,9 @@
+#[cfg(wrong_lib)]
+pub fn hello_world() -> String {
+    String::rom("Hello, world!")
+}
+
+#[cfg(not(wrong_lib))]
 pub fn hello_world() -> String {
     String::from("Hello, world!")
 }

--- a/tests/fixtures/multitarget/src/main.rs
+++ b/tests/fixtures/multitarget/src/main.rs
@@ -1,5 +1,11 @@
 extern crate multitarget;
 
+#[cfg(wrong_bin)]
+fn main() {
+    println!("{}", &multitarget::helloworld());
+}
+
+#[cfg(not(wrong_bin))]
 fn main() {
     println!("{}", &multitarget::hello_world());
 }

--- a/tests/multitarget.rs
+++ b/tests/multitarget.rs
@@ -1,7 +1,7 @@
 // static BINARY: &'static str = concat!(env!("CARGO_TARGET_DIR"), env!("CARGO_PKG_NAME"));
 
 use std::env;
-use std::process::{Command, Stdio};
+use std::process::Command;
 use std::path::PathBuf;
 
 fn cargo_check() -> Command {
@@ -25,6 +25,57 @@ fn multiple_targets() {
 
     let status = cargo_check()
         .arg("check")
+        .current_dir(multiple_target_fixture)
+        .status()
+        .unwrap();
+
+    assert!(status.success());
+}
+
+#[test]
+fn multiple_targets_2() {
+    let multiple_target_fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/multitarget");
+
+    let status = cargo_check()
+        .args(&["check", "--", "--cfg", "wrong_bin"])
+        .current_dir(multiple_target_fixture)
+        .status()
+        .unwrap();
+
+    assert!(!status.success());
+}
+
+// The test ensures that `cargo check` bails after first failing compilation.
+#[test]
+fn multiple_targets_3() {
+    let multiple_target_fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/multitarget");
+
+    let output = cargo_check()
+        .args(&["check", "--", "--cfg", "wrong_bin", "--cfg", "wrong_lib"])
+        .current_dir(multiple_target_fixture)
+        .output()
+        .unwrap()
+        .stderr;
+
+    let output = String::from_utf8(output).unwrap();
+
+    // This is the error message from compiling `--lib`
+    assert!(output.contains("no associated item"));
+    // This is the error message from compiling `--bin multitarget`.
+    // This should not be present as `cargo check` should bail after first
+    // failure.
+    assert!(!output.contains("unresolved name"));
+}
+
+#[test]
+fn multiple_targets_4() {
+    let multiple_target_fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/multitarget");
+
+    let status = cargo_check()
+        .args(&["check", "--release"])
         .current_dir(multiple_target_fixture)
         .status()
         .unwrap();


### PR DESCRIPTION
See discussion in #13 for details.

I also cleaned up some code, removed some tests in favor of actually testing compilation of broken crates. Diff of `src/main.rs` is +18 -59, major additions are the new tests. Please test this out manually once before merging!

(I will be submitting another PR to enable checking of benches and tests that are in their own files instead of being in the lib or bin. I didn't want to add too many things to one PR.)

cc @euclio 