### PR TITLE
Add '--version' flag and exit cleanly on 'cargo metadata' errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-check"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Ray Solomon <raybsolomon@gmail.com>"]
 license = "MIT OR Apache-2.0"
 description = "wrapper around cargo rustc -- -Zno-trans"


### PR DESCRIPTION
The version flag makes it possible to distinguish capabilities when using the tool from other places.
The fix for cargo metadata is to avoid getting a nasty stack trace when invoking the tool from a folder that isn't a cargo project.