### PR TITLE
Fix tests on beta

### DIFF
--- a/tests/multitarget.rs
+++ b/tests/multitarget.rs
@@ -5,7 +5,12 @@ use std::process::Command;
 use std::path::PathBuf;
 
 fn cargo_check() -> Command {
-    Command::new(env::current_exe().unwrap().parent().unwrap().join("cargo-check"))
+    let mut me = env::current_exe().unwrap();
+    me.pop();
+    if me.ends_with("deps") {
+        me.pop();
+    }
+    Command::new(me.join("cargo-check"))
 }
 
 #[test]


### PR DESCRIPTION
Cargo's output directory structure changed slightly on beta, so this updates the
test suite to accommodate for those changes.

cc rust-lang/rust#38722